### PR TITLE
Fix off-by-one in shield booster combinations

### DIFF
--- a/lib/Get-LoadoutList.ps1
+++ b/lib/Get-LoadoutList.ps1
@@ -5,7 +5,7 @@ Function Get-LoadoutList{
     )
     
     $i = 1
-    $Loadout = $(@(0) * $ShieldBoosterCount)
+    $Loadout = $(@(1) * $ShieldBoosterCount)
     $LoadoutList = @{}
     $LoadoutList[$i] = $Loadout
 

--- a/lib/One-Up.ps1
+++ b/lib/One-Up.ps1
@@ -9,7 +9,7 @@ Function One-up{
     $NextLoadout = @()
     $CurrentLoadout | ForEach-Object{$NextLoadout += $_}
 
-    If($NextLoadout[$CurrentShieldBooster] -lt ($ShieldBoosterVariants -1)){
+    If($NextLoadout[$CurrentShieldBooster] -lt ($ShieldBoosterVariants)){
         $NextLoadout[$CurrentShieldBooster] += 1
     }Else{
         If($CurrentShieldBooster -ne $($ShieldBoosterCount -1)){


### PR DESCRIPTION
This allows Resistance Augmented / Super Capacitors to be tried.

Found this because my [Rust port](https://github.com/Freaky/elite_shield_tester) didn't have the problem, unless I dropped the very last entry from the boosters list... :)