### PR TITLE
Fix typo in file paths so it will work on case sensitive file systems

### DIFF
--- a/GoShieldTester/config.go
+++ b/GoShieldTester/config.go
@@ -24,7 +24,7 @@ func loadConfig() configT {
 		scbHitPoint:            0,
 		guardianShieldHitPoint: 0,
 		boosterFile:            "../ShieldBoosterVariants_short.csv",
-		generatorFile:          "../shieldGeneratorVariants.csv",
+		generatorFile:          "../ShieldGeneratorVariants.csv",
 	}
 
 	return config


### PR DESCRIPTION
This should allow the Go port to work on Linux and BSD file systems again. It still works on Windows. I believe MacOS X is case insensitive, but will benefit from this patch as well. 